### PR TITLE
update list.concat to list.flatten

### DIFF
--- a/src/nessie_cluster.gleam
+++ b/src/nessie_cluster.gleam
@@ -362,7 +362,7 @@ pub fn default_resolver() -> Resolver {
 
       let #(ips, _) =
         [ipv4_addrs, ipv6_addrs]
-        |> list.concat()
+        |> list.flatten()
         |> list.map(nessie.ip_to_string)
         |> result.partition()
 


### PR DESCRIPTION
nessie_cluster did not compile in gleam 1.7.0.
`list.concat` was deprecated and later removed in favor of `list.flatten` 

ref: https://hexdocs.pm/gleam_stdlib/gleam/list.html#flatten

As I haven't had the opportunity to contribute to OSS before, feel free to give me pointer on anything at all.